### PR TITLE
Misc changes to match documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ travis-ci = { "repository" = "slog-rs/journald" }
 [dependencies]
 slog = "2.0.4"
 libc = "0.2"
-libsystemd-sys = "0.0"
+libsystemd-sys = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,3 +212,21 @@ impl slog::Serializer for Serializer {
     __emitter!(emit_str: &str);
     __emitter!(emit_arguments: &std::fmt::Arguments);
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizer_no_leading_underscores() {
+        assert_eq!(SanitizedKey("_A").to_string(), "A");
+        assert_eq!(SanitizedKey("__A").to_string(), "A");
+    }
+
+    #[test]
+    fn sanitizer_allow_inner_underscore() {
+        assert_eq!(SanitizedKey("A_A").to_string(), "A_A");
+        assert_eq!(SanitizedKey("A__A").to_string(), "A__A");
+        assert_eq!(SanitizedKey("A__A_").to_string(), "A__A_");
+    }
+}


### PR DESCRIPTION
Public documentation on the `JournaldDrain` type says:

> Journald requires keys to be uppercase alphanumeric, so logging keys are capitalized and all non-alpha-numeric letters are converted to underscores.

However, the implementation (and the doc comments on the private `SanitizedKey`) instead drop all characters not in `[-_A-Za-z0-9]`

Additionally, the code to not emit an underscore as the first character wasn't correct: It was actually checking if the *second* character is an underscore or dash. This also meant things like `___A` would still be left with a leading underscore.