### PR TITLE
fix compiler warnings on rust 1.45.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ impl Display for Error {
 }
 
 impl std::error::Error for Error {
+    #[allow(deprecated)] // using std::error::Error::description : deprecated since rust 1.42.0
     fn description(&self) -> &str {
         match *self {
             Error::Journald(_) => "Unable to send to journald",
@@ -151,14 +152,14 @@ impl<'a> Display for SanitizedKey {
         for c in key.chars() {
             match c {
                 'A'..='Z' | '0'..='9' => {
-                    try!(fmt.write_char(c));
+                    fmt.write_char(c)?;
                     found_non_underscore = true;
                 }
                 'a'..='z' => {
-                    try!(fmt.write_char(c.to_ascii_uppercase()));
+                    fmt.write_char(c.to_ascii_uppercase())?;
                     found_non_underscore = true;
                 }
-                _ if found_non_underscore => try!(fmt.write_char('_')),
+                _ if found_non_underscore => fmt.write_char('_')?,
                 _ => {}
             }
         }


### PR DESCRIPTION
 3 lines : change `try!` to `?`

```
warning: use of deprecated item 'try': use the `?` operator instead
   --> src/lib.rs:154:21
    |
154 |                     try!(fmt.write_char(c));
    |                     ^^^
    |
    = note: `#[warn(deprecated)]` on by default
```

 add `#[allow(deprecated)]` for slog_journald::Error::description

```
warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
  --> src/lib.rs:88:46
   |
88 |             Error::Serialization(ref e) => e.description(),
   |                                              ^^^^^^^^^^^

```