### PR TITLE
Implemented specialized serialization of errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log_errno = []
 log_error_sources = []
 
 [dependencies]
-slog = "2.6"
+slog = "2.7"
 libc = "0.2"
 libsystemd-sys = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,23 @@ homepage = "https://github.com/slog-rs/journald"
 repository = "https://github.com/slog-rs/journald"
 readme = "README.md"
 
+[badges]
+travis-ci = { "repository" = "slog-rs/journald" }
+
+[features]
+# Logs errno from io::Error if present.
+# Requires Rust 1.30+
+log_errno = []
+# Log sources of error one-by-one
+# The outermost error is logged as ERROR_SOURCE_0
+# The following error is logged as ERROR_SOURCE_1
+# The length of error-source chain is logged as ERROR_SOURCE_DEPTH
+log_error_sources = []
+
 [dependencies]
-slog = "2.5"
+slog = "2.6"
 libc = "0.2"
 libsystemd-sys = "0.2"
+
+[patch.crates-io.slog]
+git = "https://github.com/slog-rs/slog"

--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@
 This is a straightforward journald drain for [slog-rs](https://github.com/dpc/slog-rs).
 
 Journald and slog-rs work very well together since both support structured log data. This crate will convert structured data (that is, key-value pairs) into journald fields. Since, journald field names are more restrictive than keys in slog-rs, key names are sanitized to be valid journald fields.
+
+This crate supports specialized handling of logged errors via features. Look into `Cargo.toml` for more information.
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 //! Since Journald supports structured data, structured data passed to slog is
 //! simply forwarded to Journald as structured data.
 //!
+//! This crate supports specialized handling of logged errors via features.
+//! Look into `Cargo.toml` for more information.
+//!
 //! # Examples
 //! ```
 //! #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ extern crate slog;
 use std::ascii::AsciiExt;
 use std::fmt::{Display, Formatter, Write};
 use std::os::raw::{c_int, c_void};
+use std::fmt;
 
 use libc::{size_t, LOG_CRIT, LOG_DEBUG, LOG_ERR, LOG_INFO, LOG_NOTICE, LOG_WARNING};
 use libsystemd_sys::const_iovec;
@@ -223,6 +224,52 @@ impl slog::Serializer for Serializer {
     __emitter!(emit_isize: isize);
     __emitter!(emit_str: &str);
     __emitter!(emit_arguments: &std::fmt::Arguments);
+
+    fn emit_error(&mut self, key: Key, error: &(std::error::Error + 'static)) -> slog::Result {
+        #[cfg(feature = "log_errno")]
+        {
+            let mut error_source = Some(error);
+            while let Some(source) = error_source {
+                if let Some(io_error) = source.downcast_ref::<std::io::Error>() {
+                    if let Some(errno) = io_error.raw_os_error() {
+                        self.add_field(format!("ERRNO={}", errno));
+                    }
+                }
+                error_source = source.source();
+            }
+        }
+        #[cfg(feature = "log_error_sources")]
+        {
+            let mut error_cause = Some(error);
+            let mut depth = 0usize;
+            while let Some(cause) = error_cause {
+                self.add_field(format!("ERROR_SOURCE_{}={}", depth, cause));
+                depth += 1;
+                error_cause = cause.cause();
+            }
+            self.add_field(format!("ERROR_SOURCE_DEPTH={}", depth));
+        }
+
+        self.emit_arguments(key, &format_args!("{}", ErrorAsFmt(error)))
+    }
+}
+
+// copied from slog
+struct ErrorAsFmt<'a>(pub &'a (std::error::Error + 'static));
+
+impl<'a> fmt::Display for ErrorAsFmt<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // For backwards compatibility
+        // This is fine because we don't need downcasting
+        #![allow(deprecated)]
+        write!(f, "{}", self.0)?;
+        let mut error = self.0.cause();
+        while let Some(source) = error {
+            write!(f, ": {}", source)?;
+            error = source.cause();
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,9 @@ extern crate slog;
 
 #[allow(deprecated, unused_imports)]
 use std::ascii::AsciiExt;
+use std::fmt;
 use std::fmt::{Display, Formatter, Write};
 use std::os::raw::{c_int, c_void};
-use std::fmt;
 
 use libc::{size_t, LOG_CRIT, LOG_DEBUG, LOG_ERR, LOG_INFO, LOG_NOTICE, LOG_WARNING};
 use libsystemd_sys::const_iovec;


### PR DESCRIPTION
This change makes use of the new `slog` feature which allows
specializing error types. When an error type is encountered, it can be
inspected to check if it contains an errno. If it does, the standard
`ERRNO=` field will be added. This however requires a newer version of
Rust (1.30+), so it's an opt-in feature.

Further, logging of error sources separately is supported. This is also
behind a feature flag as some users might find it redundant. Making it
runtime configurable would be nicer, but such would be a breaking change
because the `JournaldDrain` struct was not future-proofed. It should be
quite easy to make a new breaking release with this option though. This
feature calls `cause()` so it does not require a new version of Rust. To
aid log analyzers, it also logs the depth of the error chain.

Finally each error is logged as in the case of the default
implementation. The features described above do not interfere with this.
It could be also configurable but I'm not sure how to best achieve it.
The displaying code was copy-pasted from the `slog` crate because it's
not public. It's a good question whether it should be made public, or
even moved to a different crate.

This is a draft because the new `slog` version was not released yet. @dpc what exactly is your policy on releases? Perhaps a crate attempting to actually use the new feature could be a good opportunity for a release?
But maybe only after we separate-out the code for default error formatting?